### PR TITLE
Convert type and meta in options

### DIFF
--- a/ImageRecoder/Options.cs
+++ b/ImageRecoder/Options.cs
@@ -28,12 +28,12 @@ namespace ImageRecoder
         [Value(1, MetaName = "output", Required = true, HelpText = "Output file path.")]
         public string Output { get; set; }
 
-        [Option("type", Required = true, HelpText = @"
+        [Option(shortName: 't', longName: "type", Required = true, HelpText = @"
 1 - Takes the picture and saves it, removing most of metadata or byte hidden contents.
 2 - Takes the picture and saves it to raw BMP HEX, removing all the sensitive information stored in a file.")]
         public ProcessingType Type { get; set; }
 
-        [Option("meta", Required = false, Default = Meta.NoPostProcessing, HelpText = @"
+        [Option(shortName: 'm', longName: "meta", Required = false, Default = Meta.NoPostProcessing, HelpText = @"
 [0] - No post-processing
 1 - 1/5 colour equalization to remove a bit of hidden contents.
 2 - 1/10 colour equalization to remove some of hidden contents.

--- a/ImageRecoder/Options.cs
+++ b/ImageRecoder/Options.cs
@@ -28,12 +28,12 @@ namespace ImageRecoder
         [Value(1, MetaName = "output", Required = true, HelpText = "Output file path.")]
         public string Output { get; set; }
 
-        [Value(2, MetaName = "type", Required = true, HelpText = @"
+        [Option("type", Required = true, HelpText = @"
 1 - Takes the picture and saves it, removing most of metadata or byte hidden contents.
 2 - Takes the picture and saves it to raw BMP HEX, removing all the sensitive information stored in a file.")]
         public ProcessingType Type { get; set; }
 
-        [Value(3, MetaName = "meta", Required = false, Default = Meta.NoPostProcessing, HelpText = @"
+        [Option("meta", Required = false, Default = Meta.NoPostProcessing, HelpText = @"
 [0] - No post-processing
 1 - 1/5 colour equalization to remove a bit of hidden contents.
 2 - 1/10 colour equalization to remove some of hidden contents.

--- a/ImageRecoder/Program.cs
+++ b/ImageRecoder/Program.cs
@@ -25,9 +25,7 @@ namespace ImageRecoder
         {
             var helpText = HelpText.AutoBuild(result, helpText =>
             {
-                helpText.Heading = string.Empty;
-                helpText.Copyright = string.Empty;
-                helpText.AddPreOptionsLine("Usage: program.exe <input> <output> <type> [meta]");
+                helpText.AddPreOptionsLine("Usage: program.exe <input> <output> --type <type> [-- meta <meta>]");
                 helpText.AddPostOptionsLine("Program source code: https://github.com/kolya5544/FreeNet/tree/master/ImageRecoder");
                 return HelpText.DefaultParsingErrorsHandler(result, helpText);
             }, e => e);
@@ -130,7 +128,7 @@ namespace ImageRecoder
             Baker.FileSizeHeader(ms, BMPSize);
             //Application specific header. It will be...
             Baker.IKTMHeader(ms, new byte[] { 0x00, 0x00, 0x00, 0x00 }); //There was an "IKTM" header but now just zeroes
-                                          //Static offset of pixel data.
+                                                                         //Static offset of pixel data.
             Baker.PixelOffsetHeader(ms);
             //DIB header, fully handled by one function (it's mostly static.)
             Baker.DIB(ms, bmp.Width, bmp.Height);
@@ -179,7 +177,8 @@ namespace ImageRecoder
                 int NewG = (G / Ratio) * Ratio;
                 int NewB = (B / Ratio) * Ratio;
                 c = Color.FromArgb(c.A, NewR, NewG, NewB);
-            } else
+            }
+            else
             {
                 double Colour = c.R * 0x10000 + c.G * 0x100 + c.B;
                 double BWpercentage = Colour / 0xFFFFFF;

--- a/ImageRecoder/Properties/launchSettings.json
+++ b/ImageRecoder/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ImageRecoder": {
       "commandName": "Project",
-      "commandLineArgs": ".\\test2.jpg hi.bmp 2 7"
+      "commandLineArgs": ".\\test2.jpg hi.bmp --type 2 --meta 7"
     }
   }
 }


### PR DESCRIPTION
* Convert `meta` and `type` in options, with both short and long names now
* Add tool name and copyright (can be edited in the assembly). This can be removed at any time reverting the changes in `Program.cs` file.

New usage is `program.exe a.jpg b.png --type 2 --meta 7`, or `program.exe a.jpg b.png -t 2 -m 7`

Master (left) vs this branch (right).
![image](https://user-images.githubusercontent.com/11148519/95101201-2c6c8200-0732-11eb-89ce-aaecb0057df6.png).

You have write access to the branch in case you want to make any changes.
